### PR TITLE
Use Lumo colors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,8 @@
     "vaadin-themable-mixin": "^1.1.3",
     "vaadin-notification": "^1.0.0-beta3",
     "vaadin-button": "^1.0.5",
-    "cookieconsent": "^3.0.6"
+    "cookieconsent": "^3.0.6",
+    "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.0.0"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/src/vaadin-cookie-consent.html
+++ b/src/vaadin-cookie-consent.html
@@ -8,6 +8,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../../vaadin-notification/vaadin-notification.html">
 <link rel="import" href="../../vaadin-button/vaadin-button.html">
+<link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 
 <link rel="stylesheet" type="text/css" href="../../cookieconsent/build/cookieconsent.min.css" />
 <script src="../../cookieconsent/build/cookieconsent.min.js"></script>
@@ -18,6 +19,8 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none;
       }
     </style>
+    <div id="button"></div>
+    <div id="link"></div>
   </template>
 
   <script>
@@ -60,7 +63,7 @@ This program is available under Apache License Version 2.0, available at https:/
             },
             learnMoreLink: {
               type: String,
-              value: ''
+              value: 'https://cookiesandyou.com/'
             },
             showLearnMore: {
               type: Boolean,
@@ -81,13 +84,34 @@ This program is available under Apache License Version 2.0, available at https:/
         }
         connectedCallback() {
           super.connectedCallback();
+          var backgroundColor;
+          var textColor;
+          var buttonBackgroundColor;
+          var buttonTextColor;
+          var linkTextColor;
+          if (window.ShadyCSS) {
+            backgroundColor = window.ShadyCSS.getComputedStyleValue(this, 'background-color');
+            textColor = window.ShadyCSS.getComputedStyleValue(this, 'color');
+            buttonBackgroundColor = window.ShadyCSS.getComputedStyleValue(this.$.button, 'background-color');
+            buttonTextColor = window.ShadyCSS.getComputedStyleValue(this.$.button, 'color');
+            linkTextColor =  window.ShadyCSS.getComputedStyleValue(this.$.link, 'color');
+          } else {
+            backgroundColor = getComputedStyle(this).getPropertyValue('background-color');
+            textColor = getComputedStyle(this).getPropertyValue('color');
+            buttonBackgroundColor = getComputedStyle(this.$.button).getPropertyValue('background-color');
+            buttonTextColor = getComputedStyle(this.$.button).getPropertyValue('color');
+            linkTextColor = getComputedStyle(this.$.link).getPropertyValue('color');
+          }
           window.cookieconsent.initialise({
             palette: {
               popup: {
-                background: "#000"
+                background: backgroundColor,
+                text: textColor,
+                link: linkTextColor
               },
               button: {
-                background: "#0090C0"
+                background: buttonBackgroundColor,
+                text: buttonTextColor
               }
             },
             showLink: this.showLearnMore,

--- a/theme/lumo/vaadin-cookie-consent.html
+++ b/theme/lumo/vaadin-cookie-consent.html
@@ -1,1 +1,27 @@
 <link rel="import" href="../../src/vaadin-cookie-consent.html">
+
+<link rel="import" href="../../../vaadin-lumo-styles/color.html">
+<link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-lumo-styles/style.html">
+<link rel="import" href="../../../vaadin-lumo-styles/typography.html">
+
+<dom-module id="lumo-cookie-consent" theme-for="vaadin-cookie-consent">
+<template>
+    <style>
+      :host {
+        background-color: var(--lumo-base-color);
+        color: var(--lumo-secondary-text-color);
+      }
+
+      :host #button{
+        background-color: var(--lumo-primary-color);
+        color: var(--lumo-primary-contrast-color);
+      }
+
+      :host #link{
+        color: var(--lumo-primary-text-color);
+      }
+    </style>
+  </template>
+</dom-module>


### PR DESCRIPTION
Theming with the js API. It is crappy because we need pseudoelements,
JS parsing, and we don't have a lot of control over style. Should be
switched to CSS theming but it isn't straight forwards because popup is in
body directly, and not in shadow root. With CSS, we could apply colors 
directly and add more, like Lumo box shadows to separate white body from
white popup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-cookie-consent/6)
<!-- Reviewable:end -->
