### PR TITLE
use double quotes in HTML attributes

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -18,7 +18,7 @@
       },
       "elements": [
         {
-          "description": "`<vaadin-cookie-consent>` is used to show a cookie consent banner the first\n time a user visits the application.\n\nBy default, the banner is shown attached to the top of the screen and with a\npredefined text, a link to https://cookiesandyou.com/ describing cookies and a consent button.\n\nThe texts, link and position can be configured using attributes/properties, e.g.\n```\n<vaadin-cookie-consent learn-more-link='https://mysite.com/cookies.html'></vaadin-cookie-consent>\n```",
+          "description": "`<vaadin-cookie-consent>` is used to show a cookie consent banner the first\n time a user visits the application.\n\nBy default, the banner is shown attached to the top of the screen and with a\npredefined text, a link to https://cookiesandyou.com/ describing cookies and a consent button.\n\nThe texts, link and position can be configured using attributes/properties, e.g.\n```\n<vaadin-cookie-consent learn-more-link=\"https://mysite.com/cookies.html\"></vaadin-cookie-consent>\n```",
           "summary": "",
           "path": "src/vaadin-cookie-consent.html",
           "properties": [
@@ -226,7 +226,7 @@
               "sourceRange": {
                 "start": {
                   "line": 147,
-                  "column": 9
+                  "column": 8
                 },
                 "end": {
                   "line": 153,

--- a/demo/element-basic-demos.html
+++ b/demo/element-basic-demos.html
@@ -1,6 +1,6 @@
-<dom-module id='element-basic-demos'>
+<dom-module id="element-basic-demos">
   <template>
-    <style include='vaadin-component-demo-shared-styles'>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
@@ -9,7 +9,7 @@
 
     <h3>Basic Usage</h3>
     The popup will be shown once to every user and use a standard text.
-    <vaadin-demo-snippet id='cookie-consent-demo-basic-usage'>
+    <vaadin-demo-snippet id="cookie-consent-demo-basic-usage">
       <template preserve-content>
         <vaadin-button>Show consent popup</vaadin-button>
         <vaadin-cookie-consent></vaadin-cookie-consent>

--- a/demo/element-customize-texts.html
+++ b/demo/element-customize-texts.html
@@ -1,6 +1,6 @@
-<dom-module id='element-customize-texts'>
+<dom-module id="element-customize-texts">
   <template>
-    <style include='vaadin-component-demo-shared-styles'>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
@@ -9,12 +9,12 @@
 
   <h3>Custom Values Example</h3>
   All the texts in the dialog can be customized and localized.
-  <vaadin-demo-snippet id='cookie-consent-demo-customizing-texts'>
+  <vaadin-demo-snippet id="cookie-consent-demo-customizing-texts">
     <template preserve-content>
-      <vaadin-button id='showPopup'>Show consent popup</vaadin-button>
-      <vaadin-cookie-consent 
-        message='We are using cookies to make your visit here awesome!' 
-        dismiss='Cool!' 
+      <vaadin-button id="showPopup">Show consent popup</vaadin-button>
+      <vaadin-cookie-consent
+        message='We are using cookies to make your visit here awesome!'
+        dismiss='Cool!'
         learn-more='Why?'
         learn-more-link='https://vaadin.com/terms-of-service'>
       </vaadin-cookie-consent>

--- a/demo/element-customize-texts.html
+++ b/demo/element-customize-texts.html
@@ -13,10 +13,10 @@
     <template preserve-content>
       <vaadin-button id="showPopup">Show consent popup</vaadin-button>
       <vaadin-cookie-consent
-        message='We are using cookies to make your visit here awesome!'
-        dismiss='Cool!'
-        learn-more='Why?'
-        learn-more-link='https://vaadin.com/terms-of-service'>
+        message="We are using cookies to make your visit here awesome!"
+        dismiss="Cool!"
+        learn-more="Why?"
+        learn-more-link="https://vaadin.com/terms-of-service">
       </vaadin-cookie-consent>
     </template>
     <script>

--- a/demo/element-theming.html
+++ b/demo/element-theming.html
@@ -1,6 +1,6 @@
-<dom-module id='element-theming'>
+<dom-module id="element-theming">
   <template>
-    <style include='vaadin-component-demo-shared-styles'>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
@@ -9,7 +9,7 @@
 
   <h3>Styling the Content</h3>
   The visual looks can be changed using CSS.
-  <vaadin-demo-snippet id='cookie-consent-demo-customizing-texts'>
+  <vaadin-demo-snippet id="cookie-consent-demo-customizing-texts">
     <template preserve-content>
       <style>
         div.cc-window.cc-banner {
@@ -32,7 +32,7 @@
           color: rgb(255, 81, 0);
         }
       </style>
-      <vaadin-button id='showPopup'>Show consent popup</vaadin-button>
+      <vaadin-button id="showPopup">Show consent popup</vaadin-button>
       <vaadin-cookie-consent></vaadin-cookie-consent>
     </template>
     <script>
@@ -48,7 +48,7 @@
           document.head.appendChild(window.styleTag);
 
         });
-    </script>  
+    </script>
   </vaadin-demo-snippet>
 
   </template>

--- a/src/vaadin-cookie-consent.html
+++ b/src/vaadin-cookie-consent.html
@@ -6,12 +6,12 @@ This program is available under Commercial Vaadin Add-On License 3.0 (CVALv3).
 See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete license.
 -->
 
-<link rel='import' href='../../polymer/polymer-element.html'>
-<link rel='import' href='../../vaadin-themable-mixin/vaadin-themable-mixin.html'>
-<link rel='import' href='../../vaadin-element-mixin/vaadin-element-mixin.html'>
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
 
-<script src='../../cookieconsent/build/cookieconsent.min.js'></script>
-<dom-module id='vaadin-cookie-consent'>
+<script src="../../cookieconsent/build/cookieconsent.min.js"></script>
+<dom-module id="vaadin-cookie-consent">
   <template>
     <style>
       :host {
@@ -32,7 +32,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        *
        * The texts, link and position can be configured using attributes/properties, e.g.
        * ```
-       * <vaadin-cookie-consent learn-more-link='https://mysite.com/cookies.html'></vaadin-cookie-consent>
+       * <vaadin-cookie-consent learn-more-link="https://mysite.com/cookies.html"></vaadin-cookie-consent>
        * ```
        *
        * @memberof Vaadin

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -1,16 +1,16 @@
 <!doctype html>
 
 <head>
-  <meta charset='UTF-8'>
+  <meta charset="UTF-8">
   <title>vaadin-cookie-consent tests</title>
-  <script src='../../web-component-tester/browser.js'></script>
-  <link rel='import' href='../vaadin-cookie-consent.html'>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../vaadin-cookie-consent.html">
 </head>
 
 <body>
-  <test-fixture id='default'>
+  <test-fixture id="default">
     <template>
-      <vaadin-cookie-consent cookie-name='basictestcookie'></vaadin-cookie-consent>
+      <vaadin-cookie-consent cookie-name="basictestcookie"></vaadin-cookie-consent>
     </template>
   </test-fixture>
 

--- a/test/change-texts-test.html
+++ b/test/change-texts-test.html
@@ -1,21 +1,21 @@
 <!doctype html>
 
 <head>
-  <meta charset='UTF-8'>
+  <meta charset="UTF-8">
   <title>vaadin-cookie-consent tests</title>
-  <script src='../../web-component-tester/browser.js'></script>
-  <link rel='import' href='../vaadin-cookie-consent.html'>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../vaadin-cookie-consent.html">
 </head>
 
 <body>
-    <test-fixture id='changed'>
+    <test-fixture id="changed">
         <template>
-          <vaadin-cookie-consent cookie-name='changetextscookie3' message='custom-message' dismiss='custom-dismiss' learn-more='custom-learn-more' learn-more-link='http://custom-learn-more-link/'></vaadin-cookie-consent>
+          <vaadin-cookie-consent cookie-name="changetextscookie3" message="custom-message" dismiss="custom-dismiss" learn-more="custom-learn-more" learn-more-link="http://custom-learn-more-link/"></vaadin-cookie-consent>
         </template>
       </test-fixture>
-    <test-fixture id='default'>
+    <test-fixture id="default">
     <template>
-      <vaadin-cookie-consent cookie-name='changetextscookie'></vaadin-cookie-consent>
+      <vaadin-cookie-consent cookie-name="changetextscookie"></vaadin-cookie-consent>
     </template>
   </test-fixture>
   


### PR DESCRIPTION
Reverts some unintended replacements done in https://github.com/vaadin/vaadin-cookie-consent/pull/7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-cookie-consent/26)
<!-- Reviewable:end -->
