### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-cookie-consent.html
+++ b/src/vaadin-cookie-consent.html
@@ -124,6 +124,20 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             }
           };
         }
+
+        /**
+         * @protected
+         */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(CookieConsentElement);
+          }
+        }
+
         _showLink(learnMoreLink) {
           return !!learnMoreLink;
         }
@@ -218,12 +232,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * @namespace Vaadin
        */
       window.Vaadin.CookieConsentElement = CookieConsentElement;
-
-      const licenseChecker = window.Vaadin.developmentModeCallback
-        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(CookieConsentElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-cookie-consent/62)
<!-- Reviewable:end -->
